### PR TITLE
docs: fix example todo app path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A library for creating fast optimistic updates with flexible backend support tha
 
 This library is still under design! Please let us know what you think.
 
-Checkout the [example todo app](todo-app/).
+Checkout the [example todo app](examples/react/todo).
 
 ## Installation
 


### PR DESCRIPTION
Updated the incorrect path to the example todo app in the README file to point to the correct location at examples/react/todo