### PR TITLE
feat: query collections

### DIFF
--- a/packages/optimistic/src/query/compiled-query.ts
+++ b/packages/optimistic/src/query/compiled-query.ts
@@ -1,0 +1,141 @@
+import {
+  D2,
+  type IStreamBuilder,
+  MessageType,
+  MultiSet,
+  type MultiSetArray,
+  output,
+  type RootStreamBuilder,
+} from "@electric-sql/d2ts"
+import { batch, Effect } from "@tanstack/store"
+import { compileQuery } from "./compiler.js"
+import { ResultCollection } from "./result-collection.js"
+import type { BaseQueryBuilder } from "./query-builder.js"
+import type { Context, Schema } from "./types.js"
+import { ChangeMessage } from "../types.js"
+import { Collection } from "../collection.js"
+
+export class CompiledQuery<
+  TResults extends object = Record<string, unknown>,
+> {
+  private graph: D2
+  private inputs: Record<string, RootStreamBuilder<any>>
+  private inputCollections: Record<string, Collection<any>>
+  private resultCollection: ResultCollection<TResults>
+  private state: `compiled` | `running` | `stopped` = `compiled`
+  private version: number = 0
+  private unsubscribeEffect?: () => void
+
+  constructor(queryBuilder: BaseQueryBuilder<Context<Schema>>) {
+    const query = queryBuilder._query
+    const collections = query.collections
+
+    if (!collections) {
+      throw new Error(`No collections provided`)
+    }
+
+    this.resultCollection = new ResultCollection<TResults>()
+    this.inputCollections = collections
+    this.graph = new D2({ initialFrontier: this.version })
+    this.inputs = Object.fromEntries(
+      Object.entries(collections).map(([key]) => [
+        key,
+        this.graph.newInput<any>(),
+      ])
+    )
+
+    compileQuery<IStreamBuilder<[string, unknown]>>(query, this.inputs).pipe(
+      output((msg) => {
+        if (msg.type === MessageType.DATA) {
+          this.resultCollection.applyChanges(msg.data.collection)
+        }
+      })
+    )
+  }
+
+  get results() {
+    return this.resultCollection
+  }
+
+  private sendChangesToInput(inputKey: string, changes: Array<ChangeMessage>) {
+    const input = this.inputs[inputKey]!
+    const multiSetArray: MultiSetArray<[string, unknown]> = []
+    for (const change of changes) {
+      if (change.type === `insert`) {
+        multiSetArray.push([[change.key, change.value], 1])
+      } else if (change.type === `update`) {
+        multiSetArray.push([[change.key, change.previousValue], -1])
+        multiSetArray.push([[change.key, change.value], 1])
+      } else if (change.type === `delete`) {
+        multiSetArray.push([[change.key, change.previousValue], -1])
+      }
+    }
+    input.sendData(this.version, new MultiSet(multiSetArray))
+  }
+
+  private sendFrontierToInput(inputKey: string) {
+    const input = this.inputs[inputKey]!
+    input.sendFrontier(this.version)
+  }
+
+  private sendFrontierToAllInputs() {
+    Object.entries(this.inputs).forEach(([key]) => {
+      this.sendFrontierToInput(key)
+    })
+  }
+
+  private incrementVersion() {
+    this.version++
+  }
+
+  private runGraph() {
+    this.graph.run()
+  }
+
+  start() {
+    if (this.state === `running`) {
+      throw new Error(`Query is already running`)
+    } else if (this.state === `stopped`) {
+      throw new Error(`Query is stopped`)
+    }
+
+    batch(() => {
+      Object.entries(this.inputCollections).forEach(([key, collection]) => {
+        this.sendChangesToInput(key, collection.currentStateAsChanges())
+      })
+      this.incrementVersion()
+      this.sendFrontierToAllInputs()
+      this.runGraph()
+    })
+
+    const changeEffect = new Effect({
+      fn: () => {
+        batch(() => {
+          Object.entries(this.inputCollections).forEach(([key, collection]) => {
+            this.sendChangesToInput(key, collection.derivedChanges.state)
+          })
+          this.incrementVersion()
+          this.sendFrontierToAllInputs()
+          this.runGraph()
+        })
+      },
+      deps: Object.values(this.inputCollections).map(
+        (collection) => collection.derivedChanges
+      ),
+    })
+    this.unsubscribeEffect = changeEffect.mount()
+
+    this.state = `running`
+    return () => {
+      this.stop()
+    }
+  }
+
+  stop() {
+    if (this.state === `stopped`) {
+      throw new Error(`Query is already stopped`)
+    }
+    this.unsubscribeEffect?.()
+    this.state = `stopped`
+  }
+}

--- a/packages/optimistic/src/query/index.ts
+++ b/packages/optimistic/src/query/index.ts
@@ -3,5 +3,6 @@ export {
   BaseQueryBuilder,
   type ResultFromQueryBuilder,
 } from "./query-builder.js"
-export { compileQuery } from "./compiler.js"
+export * from "./compiled-query.js"
+export * from "./pipeline-compiler.js"
 export type { Query } from "./schema.js"

--- a/packages/optimistic/src/query/pipeline-compiler.ts
+++ b/packages/optimistic/src/query/pipeline-compiler.ts
@@ -14,7 +14,7 @@ import type { IStreamBuilder } from "@electric-sql/d2ts"
  * @param inputs Mapping of table names to input streams
  * @returns A stream builder representing the compiled query
  */
-export function compileQuery<T extends IStreamBuilder<unknown>>(
+export function compileQueryPipeline<T extends IStreamBuilder<unknown>>(
   query: Query,
   inputs: Record<string, IStreamBuilder<Record<string, unknown>>>
 ): T {
@@ -45,7 +45,10 @@ export function compileQuery<T extends IStreamBuilder<unknown>>(
 
       // Compile the WITH query using the current set of inputs
       // (which includes previously compiled WITH queries)
-      const compiledWithQuery = compileQuery(withQueryWithoutWith, allInputs)
+      const compiledWithQuery = compileQueryPipeline(
+        withQueryWithoutWith,
+        allInputs
+      )
 
       // Add the compiled query to the inputs map using its alias
       allInputs[withQuery.as] = compiledWithQuery as IStreamBuilder<

--- a/packages/optimistic/src/query/query-builder.ts
+++ b/packages/optimistic/src/query/query-builder.ts
@@ -845,12 +845,12 @@ export class BaseQueryBuilder<TContext extends Context<Schema>> {
   }
 }
 
-type InitialQueryBuilder<TContext extends Context<Schema>> = Pick<
+export type InitialQueryBuilder<TContext extends Context<Schema>> = Pick<
   BaseQueryBuilder<TContext>,
   `from` | `with`
 >
 
-type QueryBuilder<TContext extends Context<Schema>> = Omit<
+export type QueryBuilder<TContext extends Context<Schema>> = Omit<
   BaseQueryBuilder<TContext>,
   `from`
 >

--- a/packages/optimistic/src/query/query-builder.ts
+++ b/packages/optimistic/src/query/query-builder.ts
@@ -23,7 +23,6 @@ import type {
   RemoveIndexSignature,
   Schema,
 } from "./types.js"
-import { CompiledQuery } from "./compiled-query"
 
 type CollectionRef = { [K: string]: Collection<any> }
 
@@ -844,16 +843,6 @@ export class BaseQueryBuilder<TContext extends Context<Schema>> {
   get _query(): Query<TContext> {
     return this.query as Query<TContext>
   }
-
-  /**
-   * Compile the query into a CompiledQuery object.
-   *
-   * @returns A new CompiledQuery object
-   */
-  compile() {
-    // TODO: add validation that the query has everything it needs
-    return new CompiledQuery<ResultsFromContext<TContext>>(this as any)
-  }
 }
 
 type InitialQueryBuilder<TContext extends Context<Schema>> = Pick<
@@ -879,7 +868,7 @@ export function queryBuilder<TBaseSchema extends Schema = {}>() {
   }>
 }
 
-type ResultsFromContext<TContext extends Context<Schema>> =
+export type ResultsFromContext<TContext extends Context<Schema>> =
   TContext[`result`] extends object
     ? TContext[`result`]
     : TContext[`result`] extends undefined

--- a/packages/optimistic/src/query/result-collection.ts
+++ b/packages/optimistic/src/query/result-collection.ts
@@ -1,0 +1,47 @@
+import { Store } from "@tanstack/store"
+import type { MultiSet } from "@electric-sql/d2ts"
+
+export class ResultCollection<T extends object = Record<string, unknown>> {
+  private resultState = new Store<Map<string, T>>(new Map())
+
+  constructor() {}
+
+  get state() {
+    return this.resultState
+  }
+
+  applyChanges(changeCollection: MultiSet<[string, unknown]>) {
+    const changesByKey = new Map<
+      string,
+      { deletes: number; inserts: number; value: unknown }
+    >()
+
+    for (const [[key, value], multiplicity] of changeCollection.getInner()) {
+      let changes = changesByKey.get(key)
+      if (!changes) {
+        changes = { deletes: 0, inserts: 0, value: value }
+        changesByKey.set(key, changes)
+      }
+
+      if (multiplicity < 0) {
+        changes.deletes += Math.abs(multiplicity)
+      } else if (multiplicity > 0) {
+        changes.inserts += multiplicity
+        changes.value = value
+      }
+    }
+
+    this.resultState.setState((state) => {
+      const newState = new Map(state)
+      for (const [key, changes] of changesByKey) {
+        const { deletes, inserts, value } = changes
+        if (inserts >= deletes) {
+          newState.set(key, value as T)
+        } else if (deletes > 0) {
+          newState.delete(key)
+        }
+      }
+      return newState
+    })
+  }
+}

--- a/packages/optimistic/src/query/result-collection.ts
+++ b/packages/optimistic/src/query/result-collection.ts
@@ -2,12 +2,16 @@ import { Store } from "@tanstack/store"
 import type { MultiSet } from "@electric-sql/d2ts"
 
 export class ResultCollection<T extends object = Record<string, unknown>> {
-  private resultState = new Store<Map<string, T>>(new Map())
+  private resultStore = new Store<Map<string, T>>(new Map())
 
   constructor() {}
 
+  get store() {
+    return this.resultStore
+  }
+
   get state() {
-    return this.resultState
+    return this.resultStore.state
   }
 
   applyChanges(changeCollection: MultiSet<[string, unknown]>) {
@@ -31,9 +35,10 @@ export class ResultCollection<T extends object = Record<string, unknown>> {
       }
     }
 
-    this.resultState.setState((state) => {
+    this.resultStore.setState((state) => {
       const newState = new Map(state)
-      for (const [key, changes] of changesByKey) {
+      for (const [rawKey, changes] of changesByKey) {
+        const key = rawKey.toString()
         const { deletes, inserts, value } = changes
         if (inserts >= deletes) {
           newState.set(key, value as T)

--- a/packages/optimistic/tests/query/compiler.test.ts
+++ b/packages/optimistic/tests/query/compiler.test.ts
@@ -7,9 +7,9 @@ import {
   output,
   v,
 } from "@electric-sql/d2ts"
-import { compileQuery } from "../../src/query/compiler.js"
+import { compileQueryPipeline } from "../../src/query/pipeline-compiler.js"
 import type { Message } from "@electric-sql/d2ts"
-import type { Query } from "../../src/query/index.js"
+import type { Query } from "../../src/query/schema.js"
 
 // Sample user type for tests
 type User = {
@@ -53,7 +53,7 @@ describe(`Query`, () => {
 
       const graph = new D2({ initialFrontier: v([0, 0]) })
       const input = graph.newInput<User>()
-      const pipeline = compileQuery(query, { [query.from]: input })
+      const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
       const messages: Array<Message<any>> = []
       pipeline.pipe(
@@ -100,7 +100,7 @@ describe(`Query`, () => {
 
       const graph = new D2({ initialFrontier: v([0, 0]) })
       const input = graph.newInput<User>()
-      const pipeline = compileQuery(query, { [query.from]: input })
+      const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
       const messages: Array<Message<any>> = []
       pipeline.pipe(
@@ -150,7 +150,7 @@ describe(`Query`, () => {
 
       const graph = new D2({ initialFrontier: v([0, 0]) })
       const input = graph.newInput<User>()
-      const pipeline = compileQuery(query, { [query.from]: input })
+      const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
       const messages: Array<Message<any>> = []
       pipeline.pipe(
@@ -197,7 +197,7 @@ describe(`Query`, () => {
 
       const graph = new D2({ initialFrontier: v([0, 0]) })
       const input = graph.newInput<User>()
-      const pipeline = compileQuery(query, { [query.from]: input })
+      const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
       const messages: Array<Message<any>> = []
       pipeline.pipe(

--- a/packages/optimistic/tests/query/conditions.test.ts
+++ b/packages/optimistic/tests/query/conditions.test.ts
@@ -7,7 +7,7 @@ import {
   output,
   v,
 } from "@electric-sql/d2ts"
-import { compileQuery } from "../../src/query/index.js"
+import { compileQueryPipeline } from "../../src/query/pipeline-compiler.js"
 import type { Message } from "@electric-sql/d2ts"
 import type { Query } from "../../src/query/index.js"
 import type {
@@ -91,7 +91,7 @@ describe(`Query`, () => {
 
       const graph = new D2({ initialFrontier: v([0, 0]) })
       const input = graph.newInput<Product>()
-      const pipeline = compileQuery(query, { [query.from]: input })
+      const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
       const messages: Array<Message<any>> = []
       pipeline.pipe(
@@ -134,7 +134,7 @@ describe(`Query`, () => {
 
       const graph = new D2({ initialFrontier: v([0, 0]) })
       const input = graph.newInput<Product>()
-      const pipeline = compileQuery(query, { [query.from]: input })
+      const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
       const messages: Array<Message<any>> = []
       pipeline.pipe(
@@ -177,7 +177,7 @@ describe(`Query`, () => {
 
       const graph = new D2({ initialFrontier: v([0, 0]) })
       const input = graph.newInput<Product>()
-      const pipeline = compileQuery(query, { [query.from]: input })
+      const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
       const messages: Array<Message<any>> = []
       pipeline.pipe(
@@ -226,7 +226,7 @@ describe(`Query`, () => {
 
       const graph = new D2({ initialFrontier: v([0, 0]) })
       const input = graph.newInput<Product>()
-      const pipeline = compileQuery(query, { [query.from]: input })
+      const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
       const messages: Array<Message<any>> = []
       pipeline.pipe(
@@ -267,7 +267,7 @@ describe(`Query`, () => {
 
       const graph = new D2({ initialFrontier: v([0, 0]) })
       const input = graph.newInput<Product>()
-      const pipeline = compileQuery(query, { [query.from]: input })
+      const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
       const messages: Array<Message<any>> = []
       pipeline.pipe(
@@ -317,7 +317,7 @@ describe(`Query`, () => {
 
       const graph = new D2({ initialFrontier: v([0, 0]) })
       const input = graph.newInput<Product>()
-      const pipeline = compileQuery(query, { [query.from]: input })
+      const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
       const messages: Array<Message<any>> = []
       pipeline.pipe(
@@ -366,7 +366,7 @@ describe(`Query`, () => {
 
       const graph = new D2({ initialFrontier: v([0, 0]) })
       const input = graph.newInput<Product>()
-      const pipeline = compileQuery(query, { [query.from]: input })
+      const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
       const messages: Array<Message<any>> = []
       pipeline.pipe(
@@ -435,7 +435,7 @@ describe(`Query`, () => {
 
       const graph = new D2({ initialFrontier: v([0, 0]) })
       const input = graph.newInput<Product>()
-      const pipeline = compileQuery(query, { [query.from]: input })
+      const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
       const messages: Array<Message<any>> = []
       pipeline.pipe(

--- a/packages/optimistic/tests/query/function-integration.test.ts
+++ b/packages/optimistic/tests/query/function-integration.test.ts
@@ -7,7 +7,7 @@ import {
   output,
   v,
 } from "@electric-sql/d2ts"
-import { compileQuery } from "../../src/query/index.js"
+import { compileQueryPipeline } from "../../src/query/pipeline-compiler.js"
 import type { Message } from "@electric-sql/d2ts"
 import type { Query } from "../../src/query/index.js"
 
@@ -78,7 +78,7 @@ describe(`Query Function Integration`, () => {
   function runQuery(query: Query): Array<any> {
     const graph = new D2({ initialFrontier: v([0, 0]) })
     const input = graph.newInput<User>()
-    const pipeline = compileQuery(query, { [query.from]: input })
+    const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
     const messages: Array<Message<any>> = []
     pipeline.pipe(

--- a/packages/optimistic/tests/query/group-by.test.ts
+++ b/packages/optimistic/tests/query/group-by.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, test } from "vitest"
 import { D2, MessageType, MultiSet, output, v } from "@electric-sql/d2ts"
-import { compileQuery } from "../../src/query/index.js"
-import type { Query } from "../../src/query/index.js"
+import { compileQueryPipeline } from "../../src/query/pipeline-compiler.js"
+import type { Query } from "../../src/query/schema.js"
 
 // Define a type for our test records
 type OrderRecord = {
@@ -85,7 +85,9 @@ describe(`D2QL GROUP BY`, () => {
   // Helper function to run a query and get results
   const runQuery = (query: Query) => {
     // Compile the query
-    const pipeline = compileQuery<any>(query, { orders: ordersInput as any })
+    const pipeline = compileQueryPipeline<any>(query, {
+      orders: ordersInput as any,
+    })
 
     // Create an output to collect the results
     const outputOp = output<any>((message) => {

--- a/packages/optimistic/tests/query/having.test.ts
+++ b/packages/optimistic/tests/query/having.test.ts
@@ -7,9 +7,9 @@ import {
   output,
   v,
 } from "@electric-sql/d2ts"
-import { compileQuery } from "../../src/query/index.js"
+import { compileQueryPipeline } from "../../src/query/pipeline-compiler.js"
 import type { Message } from "@electric-sql/d2ts"
-import type { Condition, Query } from "../../src/query/index.js"
+import type { Condition, Query } from "../../src/query/schema.js"
 
 describe(`Query - HAVING Clause`, () => {
   // Define a sample data type for our tests
@@ -109,7 +109,7 @@ describe(`Query - HAVING Clause`, () => {
 
     const graph = new D2({ initialFrontier: v([0, 0]) })
     const input = graph.newInput<Product>()
-    const pipeline = compileQuery(query, { [query.from]: input })
+    const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
     const messages: Array<Message<any>> = []
     pipeline.pipe(
@@ -153,7 +153,7 @@ describe(`Query - HAVING Clause`, () => {
 
     const graph = new D2({ initialFrontier: v([0, 0]) })
     const input = graph.newInput<Product>()
-    const pipeline = compileQuery(query, { [query.from]: input })
+    const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
     const messages: Array<Message<any>> = []
     pipeline.pipe(
@@ -202,7 +202,7 @@ describe(`Query - HAVING Clause`, () => {
 
     const graph = new D2({ initialFrontier: v([0, 0]) })
     const input = graph.newInput<Product>()
-    const pipeline = compileQuery(query, { [query.from]: input })
+    const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
     const messages: Array<Message<any>> = []
     pipeline.pipe(
@@ -256,7 +256,7 @@ describe(`Query - HAVING Clause`, () => {
 
     const graph = new D2({ initialFrontier: v([0, 0]) })
     const input = graph.newInput<Product>()
-    const pipeline = compileQuery(query, { [query.from]: input })
+    const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
     const messages: Array<Message<any>> = []
     pipeline.pipe(

--- a/packages/optimistic/tests/query/in-operator.test.ts
+++ b/packages/optimistic/tests/query/in-operator.test.ts
@@ -7,9 +7,9 @@ import {
   output,
   v,
 } from "@electric-sql/d2ts"
-import { compileQuery } from "../../src/query/index.js"
+import { compileQueryPipeline } from "../../src/query/pipeline-compiler.js"
 import type { Message } from "@electric-sql/d2ts"
-import type { Condition, Query } from "../../src/query/index.js"
+import type { Condition, Query } from "../../src/query/schema.js"
 
 describe(`Query - IN Operator`, () => {
   // Sample test data
@@ -87,7 +87,7 @@ describe(`Query - IN Operator`, () => {
 
     const graph = new D2({ initialFrontier: v([0, 0]) })
     const input = graph.newInput<TestItem>()
-    const pipeline = compileQuery(query, { [query.from]: input })
+    const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
     const messages: Array<Message<any>> = []
     pipeline.pipe(
@@ -121,7 +121,7 @@ describe(`Query - IN Operator`, () => {
 
     const graph = new D2({ initialFrontier: v([0, 0]) })
     const input = graph.newInput<TestItem>()
-    const pipeline = compileQuery(query, { [query.from]: input })
+    const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
     const messages: Array<Message<any>> = []
     pipeline.pipe(
@@ -155,7 +155,7 @@ describe(`Query - IN Operator`, () => {
 
     const graph = new D2({ initialFrontier: v([0, 0]) })
     const input = graph.newInput<TestItem>()
-    const pipeline = compileQuery(query, { [query.from]: input })
+    const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
     const messages: Array<Message<any>> = []
     pipeline.pipe(
@@ -190,7 +190,7 @@ describe(`Query - IN Operator`, () => {
 
     const graph = new D2({ initialFrontier: v([0, 0]) })
     const input = graph.newInput<TestItem>()
-    const pipeline = compileQuery(query, { [query.from]: input })
+    const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
     const messages: Array<Message<any>> = []
     pipeline.pipe(
@@ -232,7 +232,7 @@ describe(`Query - IN Operator`, () => {
 
     const graph = new D2({ initialFrontier: v([0, 0]) })
     const input = graph.newInput<TestItem>()
-    const pipeline = compileQuery(query, { [query.from]: input })
+    const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
     const messages: Array<Message<any>> = []
     pipeline.pipe(
@@ -264,7 +264,7 @@ describe(`Query - IN Operator`, () => {
 
     const graph = new D2({ initialFrontier: v([0, 0]) })
     const input = graph.newInput<TestItem>()
-    const pipeline = compileQuery(query, { [query.from]: input })
+    const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
     const messages: Array<Message<any>> = []
     pipeline.pipe(
@@ -311,7 +311,7 @@ describe(`Query - IN Operator`, () => {
 
     const graph = new D2({ initialFrontier: v([0, 0]) })
     const input = graph.newInput<TestItem>()
-    const pipeline = compileQuery(query, { [query.from]: input })
+    const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
     const messages: Array<Message<any>> = []
     pipeline.pipe(
@@ -343,7 +343,7 @@ describe(`Query - IN Operator`, () => {
 
     const graph = new D2({ initialFrontier: v([0, 0]) })
     const input = graph.newInput<TestItem>()
-    const pipeline = compileQuery(query, { [query.from]: input })
+    const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
     const messages: Array<Message<any>> = []
     pipeline.pipe(
@@ -380,7 +380,7 @@ describe(`Query - IN Operator`, () => {
 
     const graph = new D2({ initialFrontier: v([0, 0]) })
     const input = graph.newInput<TestItem>()
-    const pipeline = compileQuery(query, { [query.from]: input })
+    const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
     const messages: Array<Message<any>> = []
     pipeline.pipe(

--- a/packages/optimistic/tests/query/join.test.ts
+++ b/packages/optimistic/tests/query/join.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest"
 import { D2, MessageType, MultiSet, output } from "@electric-sql/d2ts"
-import { compileQuery } from "../../src/query/index.js"
+import { compileQueryPipeline } from "../../src/query/pipeline-compiler.js"
 import type { RootStreamBuilder } from "@electric-sql/d2ts"
-import type { Query } from "../../src/query/index.js"
+import type { Query } from "../../src/query/schema.js"
 
 describe(`Query - JOIN Clauses`, () => {
   // Sample data for users
@@ -170,7 +170,7 @@ describe(`Query - JOIN Clauses`, () => {
     }
 
     // Compile the query with the unified inputs map
-    const pipeline = compileQuery(query, inputs)
+    const pipeline = compileQueryPipeline(query, inputs)
 
     // Create a sink to collect the results
     const results: Array<any> = []

--- a/packages/optimistic/tests/query/key-by.test.ts
+++ b/packages/optimistic/tests/query/key-by.test.ts
@@ -7,8 +7,8 @@ import {
   output,
   v,
 } from "@electric-sql/d2ts"
-import { compileQuery } from "../../src/query/index.js"
-import type { Query } from "../../src/query/index.js"
+import { compileQueryPipeline } from "../../src/query/pipeline-compiler.js"
+import type { Query } from "../../src/query/schema.js"
 import type { Keyed, Message } from "@electric-sql/d2ts"
 
 // Sample user type for tests
@@ -91,7 +91,7 @@ describe(`Query keyBy`, () => {
 
     const graph = new D2({ initialFrontier: v([0, 0]) })
     const input = graph.newInput<User>()
-    const pipeline = compileQuery(query, { [query.from]: input })
+    const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
     const messages: Array<Message<any>> = []
     pipeline.pipe(
@@ -145,7 +145,7 @@ describe(`Query keyBy`, () => {
 
     const graph = new D2({ initialFrontier: v([0, 0]) })
     const input = graph.newInput<User>()
-    const pipeline = compileQuery(query, { [query.from]: input })
+    const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
     const messages: Array<Message<any>> = []
     pipeline.pipe(
@@ -189,7 +189,7 @@ describe(`Query keyBy`, () => {
 
     const graph = new D2({ initialFrontier: v([0, 0]) })
     const input = graph.newInput<User>()
-    const pipeline = compileQuery(query, { [query.from]: input })
+    const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
     const messages: Array<Message<any>> = []
     pipeline.pipe(
@@ -238,7 +238,7 @@ describe(`Query keyBy`, () => {
 
     const graph = new D2({ initialFrontier: v([0, 0]) })
     const input = graph.newInput<User>()
-    const pipeline = compileQuery(query, { [query.from]: input })
+    const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
     const messages: Array<Message<any>> = []
     pipeline.pipe(
@@ -288,7 +288,7 @@ describe(`Query keyBy`, () => {
 
     const graph = new D2({ initialFrontier: v([0, 0]) })
     const input = graph.newInput<User>()
-    const pipeline = compileQuery(query, { [query.from]: input })
+    const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
     const messages: Array<Message<any>> = []
     pipeline.pipe(
@@ -340,7 +340,7 @@ describe(`Query keyBy`, () => {
 
     // This should throw an error
     expect(() => {
-      const pipeline = compileQuery(query, { [query.from]: input })
+      const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
       pipeline.pipe(output(() => {}))
 
@@ -366,7 +366,7 @@ describe(`Query keyBy`, () => {
 
     const graph = new D2({ initialFrontier: v([0, 0]) })
     const input = graph.newInput<User>()
-    const pipeline = compileQuery(query, { [query.from]: input })
+    const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
     const messages: Array<Message<any>> = []
     pipeline.pipe(

--- a/packages/optimistic/tests/query/like-operator.test.ts
+++ b/packages/optimistic/tests/query/like-operator.test.ts
@@ -7,8 +7,8 @@ import {
   output,
   v,
 } from "@electric-sql/d2ts"
-import { compileQuery } from "../../src/query/index.js"
-import type { Condition, Query } from "../../src/query/index.js"
+import { compileQueryPipeline } from "../../src/query/pipeline-compiler.js"
+import type { Condition, Query } from "../../src/query/schema.js"
 import type { Message } from "@electric-sql/d2ts"
 
 describe(`Query - LIKE Operator`, () => {
@@ -72,7 +72,7 @@ describe(`Query - LIKE Operator`, () => {
   function runQuery(query: Query): Array<any> {
     const graph = new D2({ initialFrontier: v([0, 0]) })
     const input = graph.newInput<TestItem>()
-    const pipeline = compileQuery(query, { [query.from]: input })
+    const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
     const messages: Array<Message<any>> = []
     pipeline.pipe(
@@ -149,7 +149,7 @@ describe(`Query - LIKE Operator`, () => {
     // Create a separate graph for this test with our specific SKU test items
     const graph = new D2({ initialFrontier: v([0, 0]) })
     const input = graph.newInput<TestItem>()
-    const pipeline = compileQuery(query, { [query.from]: input })
+    const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
     const messages: Array<Message<any>> = []
     pipeline.pipe(

--- a/packages/optimistic/tests/query/nested-conditions.test.ts
+++ b/packages/optimistic/tests/query/nested-conditions.test.ts
@@ -7,7 +7,7 @@ import {
   output,
   v,
 } from "@electric-sql/d2ts"
-import { compileQuery } from "../../src/query/index.js"
+import { compileQueryPipeline } from "../../src/query/pipeline-compiler.js"
 import type { Query } from "../../src/query/index.js"
 import type { Message } from "@electric-sql/d2ts"
 import type {
@@ -307,7 +307,7 @@ describe(`Query`, () => {
 function runQuery(query: Query): Array<any> {
   const graph = new D2({ initialFrontier: v([0, 0]) })
   const input = graph.newInput<Product>()
-  const pipeline = compileQuery(query, { [query.from]: input })
+  const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
   const messages: Array<Message<any>> = []
   pipeline.pipe(

--- a/packages/optimistic/tests/query/order-by.test.ts
+++ b/packages/optimistic/tests/query/order-by.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest"
 import { D2, MessageType, MultiSet, output } from "@electric-sql/d2ts"
-import { compileQuery } from "../../src/query/index.js"
+import { compileQueryPipeline } from "../../src/query/pipeline-compiler.js"
 import type { Query } from "../../src/query/index.js"
 
 type User = {
@@ -43,7 +43,7 @@ describe(`Query`, () => {
           name: string
           age: number
         }>()
-        compileQuery(query, { users: input })
+        compileQueryPipeline(query, { users: input })
       }).toThrow(
         `LIMIT and OFFSET require an ORDER BY clause to ensure deterministic results`
       )
@@ -64,7 +64,7 @@ describe(`Query`, () => {
           name: string
           age: number
         }>()
-        compileQuery(query, { users: input })
+        compileQueryPipeline(query, { users: input })
       }).toThrow(
         `LIMIT and OFFSET require an ORDER BY clause to ensure deterministic results`
       )
@@ -85,7 +85,7 @@ describe(`Query`, () => {
         }>()
         let latestMessage: any = null
 
-        const pipeline = compileQuery(query, { input })
+        const pipeline = compileQueryPipeline(query, { input })
         pipeline.pipe(
           output((message) => {
             if (message.type === MessageType.DATA) {
@@ -140,7 +140,7 @@ describe(`Query`, () => {
         }>()
         let latestMessage: any = null
 
-        const pipeline = compileQuery(query, { input })
+        const pipeline = compileQueryPipeline(query, { input })
         pipeline.pipe(
           output((message) => {
             if (message.type === MessageType.DATA) {
@@ -194,7 +194,7 @@ describe(`Query`, () => {
         }>()
         let latestMessage: any = null
 
-        const pipeline = compileQuery(query, { input })
+        const pipeline = compileQueryPipeline(query, { input })
         pipeline.pipe(
           output((message) => {
             if (message.type === MessageType.DATA) {
@@ -245,7 +245,7 @@ describe(`Query`, () => {
         }>()
         let latestMessage: any = null
 
-        const pipeline = compileQuery(query, { input })
+        const pipeline = compileQueryPipeline(query, { input })
         pipeline.pipe(
           output((message) => {
             if (message.type === MessageType.DATA) {
@@ -316,7 +316,7 @@ describe(`Query`, () => {
         }>()
         let latestMessage: any = null
 
-        const pipeline = compileQuery(query, { input })
+        const pipeline = compileQueryPipeline(query, { input })
         pipeline.pipe(
           output((message) => {
             if (message.type === MessageType.DATA) {
@@ -382,7 +382,7 @@ describe(`Query`, () => {
         }>()
         let latestMessage: any = null
 
-        const pipeline = compileQuery(query, { input })
+        const pipeline = compileQueryPipeline(query, { input })
         pipeline.pipe(
           output((message) => {
             if (message.type === MessageType.DATA) {
@@ -438,7 +438,7 @@ describe(`Query`, () => {
         }>()
         let latestMessage: any = null
 
-        const pipeline = compileQuery(query, { input })
+        const pipeline = compileQueryPipeline(query, { input })
         pipeline.pipe(
           output((message) => {
             if (message.type === MessageType.DATA) {
@@ -493,7 +493,7 @@ describe(`Query`, () => {
         }>()
         let latestMessage: any = null
 
-        const pipeline = compileQuery(query, { input })
+        const pipeline = compileQueryPipeline(query, { input })
         pipeline.pipe(
           output((message) => {
             if (message.type === MessageType.DATA) {
@@ -545,7 +545,7 @@ describe(`Query`, () => {
         }>()
         let latestMessage: any = null
 
-        const pipeline = compileQuery(query, { input })
+        const pipeline = compileQueryPipeline(query, { input })
         pipeline.pipe(
           output((message) => {
             if (message.type === MessageType.DATA) {
@@ -616,7 +616,7 @@ describe(`Query`, () => {
         }>()
         let latestMessage: any = null
 
-        const pipeline = compileQuery(query, { input })
+        const pipeline = compileQueryPipeline(query, { input })
         pipeline.pipe(
           output((message) => {
             if (message.type === MessageType.DATA) {
@@ -680,7 +680,7 @@ describe(`Query`, () => {
         }>()
         let latestMessage: any = null
 
-        const pipeline = compileQuery(query, { input })
+        const pipeline = compileQueryPipeline(query, { input })
         pipeline.pipe(
           output((message) => {
             if (message.type === MessageType.DATA) {
@@ -735,7 +735,7 @@ describe(`Query`, () => {
         }>()
         let latestMessage: any = null
 
-        const pipeline = compileQuery(query, { input })
+        const pipeline = compileQueryPipeline(query, { input })
         pipeline.pipe(
           output((message) => {
             if (message.type === MessageType.DATA) {
@@ -789,7 +789,7 @@ describe(`Query`, () => {
         }>()
         let latestMessage: any = null
 
-        const pipeline = compileQuery(query, { input })
+        const pipeline = compileQueryPipeline(query, { input })
         pipeline.pipe(
           output((message) => {
             if (message.type === MessageType.DATA) {
@@ -840,7 +840,7 @@ describe(`Query`, () => {
         }>()
         let latestMessage: any = null
 
-        const pipeline = compileQuery(query, { input })
+        const pipeline = compileQueryPipeline(query, { input })
         pipeline.pipe(
           output((message) => {
             if (message.type === MessageType.DATA) {
@@ -917,7 +917,7 @@ describe(`Query`, () => {
         }>()
         let latestMessage: any = null
 
-        const pipeline = compileQuery(query, { input })
+        const pipeline = compileQueryPipeline(query, { input })
         pipeline.pipe(
           output((message) => {
             if (message.type === MessageType.DATA) {
@@ -989,7 +989,7 @@ describe(`Query`, () => {
         }>()
         let latestMessage: any = null
 
-        const pipeline = compileQuery(query, { input })
+        const pipeline = compileQueryPipeline(query, { input })
         pipeline.pipe(
           output((message) => {
             if (message.type === MessageType.DATA) {
@@ -1045,7 +1045,7 @@ describe(`Query`, () => {
         }>()
         let latestMessage: any = null
 
-        const pipeline = compileQuery(query, { input })
+        const pipeline = compileQueryPipeline(query, { input })
         pipeline.pipe(
           output((message) => {
             if (message.type === MessageType.DATA) {
@@ -1100,7 +1100,7 @@ describe(`Query`, () => {
         }>()
         let latestMessage: any = null
 
-        const pipeline = compileQuery(query, { input })
+        const pipeline = compileQueryPipeline(query, { input })
         pipeline.pipe(
           output((message) => {
             if (message.type === MessageType.DATA) {
@@ -1152,7 +1152,7 @@ describe(`Query`, () => {
         }>()
         let latestMessage: any = null
 
-        const pipeline = compileQuery(query, { input })
+        const pipeline = compileQueryPipeline(query, { input })
         pipeline.pipe(
           output((message) => {
             if (message.type === MessageType.DATA) {
@@ -1229,7 +1229,7 @@ describe(`Query`, () => {
         }>()
         let latestMessage: any = null
 
-        const pipeline = compileQuery(query, { input })
+        const pipeline = compileQueryPipeline(query, { input })
         pipeline.pipe(
           output((message) => {
             if (message.type === MessageType.DATA) {
@@ -1299,7 +1299,7 @@ describe(`Query`, () => {
         }>()
         let latestMessage: any = null
 
-        const pipeline = compileQuery(query, { input })
+        const pipeline = compileQueryPipeline(query, { input })
         pipeline.pipe(
           output((message) => {
             if (message.type === MessageType.DATA) {
@@ -1354,7 +1354,7 @@ describe(`Query`, () => {
         }>()
         let latestMessage: any = null
 
-        const pipeline = compileQuery(query, { input })
+        const pipeline = compileQueryPipeline(query, { input })
         pipeline.pipe(
           output((message) => {
             if (message.type === MessageType.DATA) {
@@ -1408,7 +1408,7 @@ describe(`Query`, () => {
         }>()
         let latestMessage: any = null
 
-        const pipeline = compileQuery(query, { input })
+        const pipeline = compileQueryPipeline(query, { input })
         pipeline.pipe(
           output((message) => {
             if (message.type === MessageType.DATA) {
@@ -1460,7 +1460,7 @@ describe(`Query`, () => {
         }>()
         let latestMessage: any = null
 
-        const pipeline = compileQuery(query, { input })
+        const pipeline = compileQueryPipeline(query, { input })
         pipeline.pipe(
           output((message) => {
             if (message.type === MessageType.DATA) {
@@ -1530,7 +1530,7 @@ describe(`Query`, () => {
         }>()
         let latestMessage: any = null
 
-        const pipeline = compileQuery(query, { input })
+        const pipeline = compileQueryPipeline(query, { input })
         pipeline.pipe(
           output((message) => {
             if (message.type === MessageType.DATA) {
@@ -1593,7 +1593,7 @@ describe(`Query`, () => {
         }>()
         let latestMessage: any = null
 
-        const pipeline = compileQuery(query, { input })
+        const pipeline = compileQueryPipeline(query, { input })
         pipeline.pipe(
           output((message) => {
             if (message.type === MessageType.DATA) {
@@ -1649,7 +1649,7 @@ describe(`Query`, () => {
         }>()
         let latestMessage: any = null
 
-        const pipeline = compileQuery(query, { input })
+        const pipeline = compileQueryPipeline(query, { input })
         pipeline.pipe(
           output((message) => {
             if (message.type === MessageType.DATA) {
@@ -1704,7 +1704,7 @@ describe(`Query`, () => {
         }>()
         let latestMessage: any = null
 
-        const pipeline = compileQuery(query, { input })
+        const pipeline = compileQueryPipeline(query, { input })
         pipeline.pipe(
           output((message) => {
             if (message.type === MessageType.DATA) {
@@ -1762,7 +1762,7 @@ describe(`Query`, () => {
         }>()
         let latestMessage: any = null
 
-        const pipeline = compileQuery(query, { input })
+        const pipeline = compileQueryPipeline(query, { input })
         pipeline.pipe(
           output((message) => {
             if (message.type === MessageType.DATA) {

--- a/packages/optimistic/tests/query/query-builder/from.test.ts
+++ b/packages/optimistic/tests/query/query-builder/from.test.ts
@@ -24,7 +24,7 @@ interface TestSchema extends Schema {
 describe(`QueryBuilder.from`, () => {
   it(`sets the from clause correctly`, () => {
     const query = queryBuilder<TestSchema>().from(`employees`)
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
 
     expect(builtQuery.from).toBe(`employees`)
     expect(builtQuery.as).toBeUndefined()
@@ -32,7 +32,7 @@ describe(`QueryBuilder.from`, () => {
 
   it(`sets the from clause with an alias`, () => {
     const query = queryBuilder<TestSchema>().from(`employees`, `e`)
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
 
     expect(builtQuery.from).toBe(`employees`)
     expect(builtQuery.as).toBe(`e`)
@@ -44,7 +44,7 @@ describe(`QueryBuilder.from`, () => {
       .where(`@id`, `=`, 1)
       .select(`@id`, `@name`)
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
 
     expect(builtQuery.from).toBe(`employees`)
     expect(builtQuery.where).toBeDefined()

--- a/packages/optimistic/tests/query/query-builder/group-by.test.ts
+++ b/packages/optimistic/tests/query/query-builder/group-by.test.ts
@@ -27,8 +27,8 @@ describe(`QueryBuilder.groupBy`, () => {
   it(`sets a single property reference as groupBy`, () => {
     const query = queryBuilder<TestSchema>()
       .from(`employees`)
-      .select(`@department_id`, { count: { COUNT: `@id` } as any })
       .groupBy(`@department_id`)
+      .select(`@department_id`, { count: { COUNT: `@id` } as any })
 
     const builtQuery = query._query
     expect(builtQuery.groupBy).toBe(`@department_id`)
@@ -37,8 +37,8 @@ describe(`QueryBuilder.groupBy`, () => {
   it(`sets an array of property references as groupBy`, () => {
     const query = queryBuilder<TestSchema>()
       .from(`employees`)
-      .select(`@department_id`, `@salary`, { count: { COUNT: `@id` } as any })
       .groupBy([`@department_id`, `@salary`])
+      .select(`@department_id`, `@salary`, { count: { COUNT: `@id` } as any })
 
     const builtQuery = query._query
     expect(builtQuery.groupBy).toEqual([`@department_id`, `@salary`])
@@ -47,9 +47,9 @@ describe(`QueryBuilder.groupBy`, () => {
   it(`overrides previous groupBy values`, () => {
     const query = queryBuilder<TestSchema>()
       .from(`employees`)
-      .select(`@department_id`, `@salary`, { count: { COUNT: `@id` } as any })
       .groupBy(`@department_id`)
       .groupBy(`@salary`) // This should override
+      .select(`@department_id`, `@salary`, { count: { COUNT: `@id` } as any })
 
     const builtQuery = query._query
     expect(builtQuery.groupBy).toBe(`@salary`)
@@ -64,8 +64,8 @@ describe(`QueryBuilder.groupBy`, () => {
         as: `d`,
         on: [`@e.department_id`, `=`, `@d.id`],
       })
-      .select(`@d.name`, { avg_salary: { AVG: `@e.salary` } as any })
       .groupBy(`@d.name`)
+      .select(`@d.name`, { avg_salary: { AVG: `@e.salary` } as any })
 
     const builtQuery = query._query
     expect(builtQuery.groupBy).toBe(`@d.name`)
@@ -80,9 +80,9 @@ describe(`QueryBuilder.groupBy`, () => {
         as: `d`,
         on: [`@e.department_id`, `=`, `@d.id`],
       })
-      .select(`@d.name`, { total_salary: { SUM: `@e.salary` } as any })
       .groupBy(`@d.name`)
       .having({ SUM: `@e.salary` } as any, `>`, 100000)
+      .select(`@d.name`, { total_salary: { SUM: `@e.salary` } as any })
 
     const builtQuery = query._query
     expect(builtQuery.groupBy).toBe(`@d.name`)
@@ -99,9 +99,9 @@ describe(`QueryBuilder.groupBy`, () => {
         on: [`@e.department_id`, `=`, `@d.id`],
       })
       .where(`@e.salary`, `>`, 50000)
-      .select(`@d.name`, { count: { COUNT: `@e.id` } as any })
       .groupBy(`@d.name`)
       .having({ COUNT: `@e.id` } as any, `>`, 5)
+      .select(`@d.name`, { count: { COUNT: `@e.id` } as any })
       .orderBy(`@d.name`)
       .limit(10)
 

--- a/packages/optimistic/tests/query/query-builder/group-by.test.ts
+++ b/packages/optimistic/tests/query/query-builder/group-by.test.ts
@@ -30,7 +30,7 @@ describe(`QueryBuilder.groupBy`, () => {
       .select(`@department_id`, { count: { COUNT: `@id` } as any })
       .groupBy(`@department_id`)
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.groupBy).toBe(`@department_id`)
   })
 
@@ -40,7 +40,7 @@ describe(`QueryBuilder.groupBy`, () => {
       .select(`@department_id`, `@salary`, { count: { COUNT: `@id` } as any })
       .groupBy([`@department_id`, `@salary`])
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.groupBy).toEqual([`@department_id`, `@salary`])
   })
 
@@ -51,7 +51,7 @@ describe(`QueryBuilder.groupBy`, () => {
       .groupBy(`@department_id`)
       .groupBy(`@salary`) // This should override
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.groupBy).toBe(`@salary`)
   })
 
@@ -67,7 +67,7 @@ describe(`QueryBuilder.groupBy`, () => {
       .select(`@d.name`, { avg_salary: { AVG: `@e.salary` } as any })
       .groupBy(`@d.name`)
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.groupBy).toBe(`@d.name`)
   })
 
@@ -84,7 +84,7 @@ describe(`QueryBuilder.groupBy`, () => {
       .groupBy(`@d.name`)
       .having({ SUM: `@e.salary` } as any, `>`, 100000)
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.groupBy).toBe(`@d.name`)
     expect(builtQuery.having).toEqual([{ SUM: `@e.salary` }, `>`, 100000])
   })
@@ -105,7 +105,7 @@ describe(`QueryBuilder.groupBy`, () => {
       .orderBy(`@d.name`)
       .limit(10)
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
 
     // Check groupBy
     expect(builtQuery.groupBy).toBe(`@d.name`)

--- a/packages/optimistic/tests/query/query-builder/having.test.ts
+++ b/packages/optimistic/tests/query/query-builder/having.test.ts
@@ -30,7 +30,7 @@ describe(`QueryBuilder.having`, () => {
       .from(`employees`)
       .having(`@salary`, `>`, 50000)
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.having).toEqual([`@salary`, `>`, 50000])
   })
 
@@ -53,7 +53,7 @@ describe(`QueryBuilder.having`, () => {
         .from(`employees`)
         .having(`@salary`, op as any, 50000)
 
-      const builtQuery = query.buildQuery()
+      const builtQuery = query._query
       expect(builtQuery.having).toBeDefined()
       const having = builtQuery.having!
       expect(having[1]).toBe(op)
@@ -71,7 +71,7 @@ describe(`QueryBuilder.having`, () => {
       })
       .having(`@e.salary`, `>`, `@d.budget`)
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.having).toEqual([`@e.salary`, `>`, `@d.budget`])
   })
 
@@ -80,7 +80,7 @@ describe(`QueryBuilder.having`, () => {
       .from(`employees`)
       .having(50000, `<`, `@salary`)
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.having).toEqual([50000, `<`, `@salary`])
   })
 
@@ -90,7 +90,7 @@ describe(`QueryBuilder.having`, () => {
       .having(`@salary`, `>`, 50000)
       .having(`@active`, `=`, true)
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.having).toEqual([
       [`@salary`, `>`, 50000],
       `and`,
@@ -103,7 +103,7 @@ describe(`QueryBuilder.having`, () => {
 
     const query = queryBuilder<TestSchema>().from(`employees`).having(condition)
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.having).toEqual(condition)
   })
 
@@ -120,7 +120,7 @@ describe(`QueryBuilder.having`, () => {
       .groupBy(`@d.name`)
       .having({ SUM: `@e.salary` } as any, `>`, 100000)
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.groupBy).toBe(`@d.name`)
     expect(builtQuery.having).toEqual([{ SUM: `@e.salary` }, `>`, 100000])
   })
@@ -141,7 +141,7 @@ describe(`QueryBuilder.having`, () => {
       .orderBy(`@d.name`)
       .limit(10)
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.where).toBeDefined()
     expect(builtQuery.groupBy).toBeDefined()
     expect(builtQuery.having).toBeDefined()

--- a/packages/optimistic/tests/query/query-builder/join.test.ts
+++ b/packages/optimistic/tests/query/query-builder/join.test.ts
@@ -34,7 +34,7 @@ describe(`QueryBuilder.join`, () => {
         on: [`@e.department_id`, `=`, `@d.id`],
       })
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.join).toBeDefined()
     const join = builtQuery.join!
     expect(join).toHaveLength(1)
@@ -59,7 +59,7 @@ describe(`QueryBuilder.join`, () => {
           on: [`@e.department_id`, `=`, `@d.id`],
         })
 
-      const builtQuery = query.buildQuery()
+      const builtQuery = query._query
       expect(builtQuery.join).toBeDefined()
       expect(builtQuery.join![0]!.type).toBe(type)
     }
@@ -81,7 +81,7 @@ describe(`QueryBuilder.join`, () => {
         on: [`@e.department_id`, `=`, `@d2.id`],
       })
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.join).toBeDefined()
     const join = builtQuery.join!
     expect(join).toHaveLength(2)
@@ -102,7 +102,7 @@ describe(`QueryBuilder.join`, () => {
         where: [`@d.budget`, `>`, 1000000],
       })
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.join).toBeDefined()
     expect(builtQuery.join![0]!.where).toEqual([`@d.budget`, `>`, 1000000])
   })
@@ -118,7 +118,7 @@ describe(`QueryBuilder.join`, () => {
       })
       .select(`@e.id`, `@e.name`, `@d.name`, `@d.budget`)
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.select).toEqual([
       `@e.id`,
       `@e.name`,
@@ -138,7 +138,7 @@ describe(`QueryBuilder.join`, () => {
       })
       .where(`@d.budget`, `>`, 1000000)
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.where).toEqual([`@d.budget`, `>`, 1000000])
   })
 
@@ -157,7 +157,7 @@ describe(`QueryBuilder.join`, () => {
         dept_location: `@d.location`,
       })
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.from).toBe(`employees`)
     expect(builtQuery.as).toBe(`e`)
     expect(builtQuery.join).toBeDefined()

--- a/packages/optimistic/tests/query/query-builder/key-by.test.ts
+++ b/packages/optimistic/tests/query/query-builder/key-by.test.ts
@@ -30,7 +30,7 @@ describe(`QueryBuilder.keyBy`, () => {
       .select(`@id`, `@name`)
       .keyBy(`@id`)
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.keyBy).toBe(`@id`)
   })
 
@@ -40,7 +40,7 @@ describe(`QueryBuilder.keyBy`, () => {
       .select(`@id`, `@name`, `@department_id`)
       .keyBy([`@id`, `@department_id`])
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.keyBy).toEqual([`@id`, `@department_id`])
   })
 
@@ -51,7 +51,7 @@ describe(`QueryBuilder.keyBy`, () => {
       .keyBy(`@id`)
       .keyBy(`@department_id`) // This should override
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.keyBy).toBe(`@department_id`)
   })
 
@@ -67,7 +67,7 @@ describe(`QueryBuilder.keyBy`, () => {
       .select(`@e.id`, `@e.name`, `@d.name`)
       .keyBy(`@d.id`)
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.keyBy).toBe(`@d.id`)
   })
 
@@ -87,7 +87,7 @@ describe(`QueryBuilder.keyBy`, () => {
       .offset(5)
       .keyBy(`@e.id`)
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
 
     // Check keyBy
     expect(builtQuery.keyBy).toBe(`@e.id`)

--- a/packages/optimistic/tests/query/query-builder/order-by.test.ts
+++ b/packages/optimistic/tests/query/query-builder/order-by.test.ts
@@ -28,7 +28,7 @@ describe(`QueryBuilder orderBy, limit, and offset`, () => {
     it(`sets a simple string order`, () => {
       const query = queryBuilder<TestSchema>().from(`employees`).orderBy(`@id`)
 
-      const builtQuery = query.buildQuery()
+      const builtQuery = query._query
       expect(builtQuery.orderBy).toBe(`@id`)
     })
 
@@ -37,7 +37,7 @@ describe(`QueryBuilder orderBy, limit, and offset`, () => {
         .from(`employees`)
         .orderBy({ "@id": `desc` })
 
-      const builtQuery = query.buildQuery()
+      const builtQuery = query._query
       expect(builtQuery.orderBy).toEqual({ "@id": `desc` })
     })
 
@@ -46,7 +46,7 @@ describe(`QueryBuilder orderBy, limit, and offset`, () => {
         .from(`employees`)
         .orderBy([`@id`, { "@name": `asc` }])
 
-      const builtQuery = query.buildQuery()
+      const builtQuery = query._query
       expect(builtQuery.orderBy).toEqual([`@id`, { "@name": `asc` }])
     })
 
@@ -56,7 +56,7 @@ describe(`QueryBuilder orderBy, limit, and offset`, () => {
         .orderBy(`@id`)
         .orderBy(`@name`) // This should override
 
-      const builtQuery = query.buildQuery()
+      const builtQuery = query._query
       expect(builtQuery.orderBy).toBe(`@name`)
     })
   })
@@ -65,7 +65,7 @@ describe(`QueryBuilder orderBy, limit, and offset`, () => {
     it(`sets a limit on the query`, () => {
       const query = queryBuilder<TestSchema>().from(`employees`).limit(10)
 
-      const builtQuery = query.buildQuery()
+      const builtQuery = query._query
       expect(builtQuery.limit).toBe(10)
     })
 
@@ -75,7 +75,7 @@ describe(`QueryBuilder orderBy, limit, and offset`, () => {
         .limit(10)
         .limit(20) // This should override
 
-      const builtQuery = query.buildQuery()
+      const builtQuery = query._query
       expect(builtQuery.limit).toBe(20)
     })
   })
@@ -84,7 +84,7 @@ describe(`QueryBuilder orderBy, limit, and offset`, () => {
     it(`sets an offset on the query`, () => {
       const query = queryBuilder<TestSchema>().from(`employees`).offset(5)
 
-      const builtQuery = query.buildQuery()
+      const builtQuery = query._query
       expect(builtQuery.offset).toBe(5)
     })
 
@@ -94,7 +94,7 @@ describe(`QueryBuilder orderBy, limit, and offset`, () => {
         .offset(5)
         .offset(15) // This should override
 
-      const builtQuery = query.buildQuery()
+      const builtQuery = query._query
       expect(builtQuery.offset).toBe(15)
     })
   })
@@ -115,7 +115,7 @@ describe(`QueryBuilder orderBy, limit, and offset`, () => {
         .limit(10)
         .offset(5)
 
-      const builtQuery = query.buildQuery()
+      const builtQuery = query._query
       expect(builtQuery.orderBy).toEqual([`@e.salary`, { "@d.name": `asc` }])
       expect(builtQuery.limit).toBe(10)
       expect(builtQuery.offset).toBe(5)

--- a/packages/optimistic/tests/query/query-builder/select-functions.test.ts
+++ b/packages/optimistic/tests/query/query-builder/select-functions.test.ts
@@ -35,7 +35,7 @@ describe(`QueryBuilder.select with function calls`, () => {
         max_salary: { MAX: `@salary` },
       })
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.select).toMatchObject([
       `@id`,
       {
@@ -58,7 +58,7 @@ describe(`QueryBuilder.select with function calls`, () => {
         concat_text: { CONCAT: [`Employee: `, `@name`] },
       })
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.select).toMatchObject([
       `@id`,
       {
@@ -78,7 +78,7 @@ describe(`QueryBuilder.select with function calls`, () => {
         json_value: { JSON_EXTRACT: [`@name`, `$.property`] },
       })
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.select).toHaveLength(2)
     expect(builtQuery.select[1]).toHaveProperty(`json_value`)
   })
@@ -121,7 +121,7 @@ describe(`QueryBuilder.select with function calls`, () => {
         upper_name: { UPPER: `@e.name` },
       })
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.select).toHaveLength(4)
     expect(builtQuery.select[0]).toBe(`@e.id`)
     expect(builtQuery.select[1]).toBe(`@e.name`)

--- a/packages/optimistic/tests/query/query-builder/select.test.ts
+++ b/packages/optimistic/tests/query/query-builder/select.test.ts
@@ -28,7 +28,7 @@ describe(`QueryBuilder.select`, () => {
       .from(`employees`)
       .select(`@id`, `@name`)
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.select).toEqual([`@id`, `@name`])
   })
 
@@ -37,7 +37,7 @@ describe(`QueryBuilder.select`, () => {
       .from(`employees`)
       .select(`@id`, { employee_name: `@name` })
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.select).toHaveLength(2)
     expect(builtQuery.select[0]).toBe(`@id`)
     expect(builtQuery.select[1]).toHaveProperty(`employee_name`, `@name`)
@@ -50,7 +50,7 @@ describe(`QueryBuilder.select`, () => {
         upper_name: { UPPER: `@name` },
       })
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.select).toHaveLength(2)
     expect(builtQuery.select[1]).toHaveProperty(`upper_name`)
   })
@@ -61,7 +61,7 @@ describe(`QueryBuilder.select`, () => {
       .select(`@id`, `@name`)
       .select(`@id`, `@salary`) // This should override the previous select
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.select).toEqual([`@id`, `@salary`])
   })
 
@@ -70,7 +70,7 @@ describe(`QueryBuilder.select`, () => {
       .from(`employees`, `e`)
       .select(`@e.id`, `@e.name`)
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.select).toEqual([`@e.id`, `@e.name`])
   })
 
@@ -82,7 +82,7 @@ describe(`QueryBuilder.select`, () => {
 
     // We can't directly assert on types in a test, but we can check
     // that the query is constructed correctly, which implies the types work
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.select).toEqual([`@id`, `@name`])
   })
 })

--- a/packages/optimistic/tests/query/query-builder/where.test.ts
+++ b/packages/optimistic/tests/query/query-builder/where.test.ts
@@ -29,7 +29,7 @@ describe(`QueryBuilder.where`, () => {
       .from(`employees`)
       .where(`@id`, `=`, 1)
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.where).toEqual([`@id`, `=`, 1])
   })
 
@@ -52,7 +52,7 @@ describe(`QueryBuilder.where`, () => {
         .from(`employees`)
         .where(`@id`, op as any, 1)
 
-      const builtQuery = query.buildQuery()
+      const builtQuery = query._query
       expect(builtQuery.where).toBeDefined()
       // Type assertion since we know where is defined based on our query
       const where = builtQuery.where!
@@ -65,7 +65,7 @@ describe(`QueryBuilder.where`, () => {
       .from(`employees`, `e`)
       .where(`@e.department_id`, `=`, `@department.id`)
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.where).toEqual([
       `@e.department_id`,
       `=`,
@@ -78,7 +78,7 @@ describe(`QueryBuilder.where`, () => {
       .from(`employees`)
       .where(10000, `<`, `@salary`)
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.where).toEqual([10000, `<`, `@salary`])
   })
 
@@ -87,7 +87,7 @@ describe(`QueryBuilder.where`, () => {
       .from(`employees`)
       .where(`@active`, `=`, true)
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.where).toEqual([`@active`, `=`, true])
   })
 
@@ -97,7 +97,7 @@ describe(`QueryBuilder.where`, () => {
       .where(`@id`, `>`, 10)
       .where(`@salary`, `>=`, 50000)
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.where).toEqual([
       [`@id`, `>`, 10],
       `and`,
@@ -112,7 +112,7 @@ describe(`QueryBuilder.where`, () => {
       .where(`@salary`, `>=`, 50000)
       .where(`@active`, `=`, true)
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.where).toEqual([
       [[`@id`, `>`, 10], `and`, [`@salary`, `>=`, 50000]],
       `and`,
@@ -125,7 +125,7 @@ describe(`QueryBuilder.where`, () => {
 
     const query = queryBuilder<TestSchema>().from(`employees`).where(condition)
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.where).toEqual(condition)
   })
 
@@ -135,7 +135,7 @@ describe(`QueryBuilder.where`, () => {
       .where(`@salary`, `>`, 50000)
       .select(`@id`, `@name`, `@salary`)
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
     expect(builtQuery.where).toEqual([`@salary`, `>`, 50000])
     expect(builtQuery.select).toEqual([`@id`, `@name`, `@salary`])
   })

--- a/packages/optimistic/tests/query/query-builder/with.test.ts
+++ b/packages/optimistic/tests/query/query-builder/with.test.ts
@@ -48,7 +48,7 @@ describe(`QueryBuilder.with`, () => {
       .from(`emp_cte`)
       .select(`@id`, `@name`)
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
 
     expect(builtQuery.with).toBeDefined()
     expect(builtQuery.with).toHaveLength(1)
@@ -74,7 +74,7 @@ describe(`QueryBuilder.with`, () => {
       })
       .select(`@emp_cte.id`, `@emp_cte.name`, `@dept_cte.name`)
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
 
     expect(builtQuery.with).toBeDefined()
     expect(builtQuery.with).toHaveLength(2)
@@ -105,7 +105,7 @@ describe(`QueryBuilder.with`, () => {
       .where(`@id`, `>`, 100)
       .select(`@id`, { employee_name: `@name` })
 
-    const builtQuery = query.buildQuery()
+    const builtQuery = query._query
 
     expect(builtQuery.with).toBeDefined()
     expect(builtQuery.with?.[0]!.where).toBeDefined()

--- a/packages/optimistic/tests/query/query-collection.test.ts
+++ b/packages/optimistic/tests/query/query-collection.test.ts
@@ -3,6 +3,7 @@ import mitt from "mitt"
 import { Collection } from "../../src/collection.js"
 import { queryBuilder } from "../../src/query/query-builder.js"
 import { compileQuery } from "../../src/query/compiled-query.js"
+import type { PendingMutation } from "../../src/types.js"
 
 type Person = {
   id: string
@@ -10,6 +11,13 @@ type Person = {
   age: number
   email: string
   isActive: boolean
+}
+
+type Issue = {
+  id: string
+  title: string
+  description: string
+  userId: string
 }
 
 const initialPersons: Array<Person> = [
@@ -36,6 +44,27 @@ const initialPersons: Array<Person> = [
   },
 ]
 
+const initialIssues: Array<Issue> = [
+  {
+    id: `1`,
+    title: `Issue 1`,
+    description: `Issue 1 description`,
+    userId: `1`,
+  },
+  {
+    id: `2`,
+    title: `Issue 2`,
+    description: `Issue 2 description`,
+    userId: `2`,
+  },
+  {
+    id: `3`,
+    title: `Issue 3`,
+    description: `Issue 3 description`,
+    userId: `1`,
+  },
+]
+
 describe(`Query Collections`, async () => {
   it(`should be able to query a collection`, async () => {
     const emitter = mitt()
@@ -48,7 +77,7 @@ describe(`Query Collections`, async () => {
         sync: ({ begin, write, commit }) => {
           // Listen for sync events
           // @ts-expect-error don't trust Mitt's typing and this works.
-          emitter.on(`sync`, (changes: Array<PendingMutation>) => {
+          emitter.on(`sync`, (changes: Array<PendingMutation<Person>>) => {
             begin()
             changes.forEach((change) => {
               write({
@@ -153,6 +182,178 @@ describe(`Query Collections`, async () => {
 
     expect(result.state.size).toBe(1)
     expect(result.state.get(`4`)).toBeUndefined()
+  })
+
+  it(`should join collections and return combined results`, async () => {
+    const emitter = mitt()
+
+    // Create person collection
+    const personCollection = new Collection<Person>({
+      id: `person-collection-test`,
+      sync: {
+        sync: ({ begin, write, commit }) => {
+          // @ts-expect-error Mitt typing doesn't match our usage
+          emitter.on(
+            `sync-person`,
+            (changes: Array<PendingMutation<Person>>) => {
+              begin()
+              changes.forEach((change) => {
+                write({
+                  key: change.key,
+                  type: change.type,
+                  value: change.changes,
+                })
+              })
+              commit()
+            }
+          )
+        },
+      },
+      mutationFn: async ({ transaction }) => {
+        emitter.emit(`sync-person`, transaction.mutations)
+        return Promise.resolve()
+      },
+    })
+
+    // Create issue collection
+    const issueCollection = new Collection<Issue>({
+      id: `issue-collection-test`,
+      sync: {
+        sync: ({ begin, write, commit }) => {
+          // @ts-expect-error Mitt typing doesn't match our usage
+          emitter.on(`sync-issue`, (changes: Array<PendingMutation<Issue>>) => {
+            begin()
+            changes.forEach((change) => {
+              write({
+                key: change.key,
+                type: change.type,
+                value: change.changes,
+              })
+            })
+            commit()
+          })
+        },
+      },
+      mutationFn: async ({ transaction }) => {
+        emitter.emit(`sync-issue`, transaction.mutations)
+        return Promise.resolve()
+      },
+    })
+
+    // Sync initial person data
+    emitter.emit(
+      `sync-person`,
+      initialPersons.map((person) => ({
+        key: person.id,
+        type: `insert`,
+        changes: person,
+      }))
+    )
+
+    // Sync initial issue data
+    emitter.emit(
+      `sync-issue`,
+      initialIssues.map((issue) => ({
+        key: issue.id,
+        type: `insert`,
+        changes: issue,
+      }))
+    )
+
+    // Create a query with a join between persons and issues
+    const query = queryBuilder()
+      .from({ issues: issueCollection })
+      .join({
+        type: `inner`,
+        from: { persons: personCollection },
+        on: [`@persons.id`, `=`, `@issues.userId`],
+      })
+      .select(`@issues.id`, `@issues.title`, `@persons.name`)
+      .keyBy(`@id`)
+
+    const compiledQuery = compileQuery(query)
+    compiledQuery.start()
+
+    const result = compiledQuery.results
+
+    await waitForChanges()
+
+    // Verify that we have the expected joined results
+    expect(result.state.size).toBe(3)
+
+    expect(result.state.get(`1`)).toEqual({
+      id: `1`,
+      name: `John Doe`,
+      title: `Issue 1`,
+    })
+
+    expect(result.state.get(`2`)).toEqual({
+      id: `2`,
+      name: `Jane Doe`,
+      title: `Issue 2`,
+    })
+
+    expect(result.state.get(`3`)).toEqual({
+      id: `3`,
+      name: `John Doe`,
+      title: `Issue 3`,
+    })
+
+    // Add a new issue for user 1
+    emitter.emit(`sync-issue`, [
+      {
+        key: `4`,
+        type: `insert`,
+        changes: {
+          id: `4`,
+          title: `Issue 4`,
+          description: `Issue 4 description`,
+          userId: `2`,
+        },
+      },
+    ])
+
+    await waitForChanges()
+
+    expect(result.state.size).toBe(4)
+    expect(result.state.get(`4`)).toEqual({
+      id: `4`,
+      name: `Jane Doe`,
+      title: `Issue 4`,
+    })
+
+    // Update an issue we're already joined with
+    emitter.emit(`sync-issue`, [
+      {
+        key: `2`,
+        type: `update`,
+        changes: {
+          title: `Updated Issue 2`,
+        },
+      },
+    ])
+
+    await waitForChanges()
+
+    // The updated title should be reflected in the joined results
+    expect(result.state.get(`2`)).toEqual({
+      id: `2`,
+      name: `Jane Doe`,
+      title: `Updated Issue 2`,
+    })
+
+    // Delete an issue
+    emitter.emit(`sync-issue`, [
+      {
+        key: `3`,
+        type: `delete`,
+      },
+    ])
+
+    await waitForChanges()
+
+    // After deletion, user 3 should no longer have a joined result
+    expect(result.state.get(`3`)).toBeUndefined()
   })
 })
 

--- a/packages/optimistic/tests/query/query-collection.test.ts
+++ b/packages/optimistic/tests/query/query-collection.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it, vi } from "vitest"
+import mitt from "mitt"
+import { Collection } from "../../src/collection.js"
+import { queryBuilder } from "../../src/query/query-builder.js"
+import { compileQuery } from "../../src/query/compiled-query.js"
+
+type Person = {
+  id: string
+  name: string
+  age: number
+  email: string
+  isActive: boolean
+}
+
+const initialPersons: Array<Person> = [
+  {
+    id: `1`,
+    name: `John Doe`,
+    age: 30,
+    email: `john.doe@example.com`,
+    isActive: true,
+  },
+  {
+    id: `2`,
+    name: `Jane Doe`,
+    age: 25,
+    email: `jane.doe@example.com`,
+    isActive: true,
+  },
+  {
+    id: `3`,
+    name: `John Smith`,
+    age: 35,
+    email: `john.smith@example.com`,
+    isActive: true,
+  },
+]
+
+describe(`Query Collections`, async () => {
+  it(`should be able to query a collection`, async () => {
+    const emitter = mitt()
+    const callback = vi.fn()
+
+    // Create collection with mutation capability
+    const collection = new Collection<Person>({
+      id: `optimistic-changes-test`,
+      sync: {
+        sync: ({ begin, write, commit }) => {
+          // Listen for sync events
+          // @ts-expect-error don't trust Mitt's typing and this works.
+          emitter.on(`sync`, (changes: Array<PendingMutation>) => {
+            begin()
+            changes.forEach((change) => {
+              write({
+                key: change.key,
+                type: change.type,
+                value: change.changes,
+              })
+            })
+            commit()
+          })
+        },
+      },
+      mutationFn: async ({ transaction }) => {
+        emitter.emit(`sync`, transaction.mutations)
+        return Promise.resolve()
+      },
+    })
+
+    // Sync from initial state
+    emitter.emit(
+      `sync`,
+      initialPersons.map((person) => ({
+        key: person.id,
+        type: `insert`,
+        changes: person,
+      }))
+    )
+
+    const query = queryBuilder()
+      .from({ collection })
+      .where(`@age`, `>`, 30)
+      .keyBy(`@id`)
+      .select(`@id`, `@name`)
+
+    const compiledQuery = compileQuery(query)
+
+    compiledQuery.start()
+
+    const result = compiledQuery.results
+
+    expect(result.state.size).toBe(1)
+    expect(result.state.get(`3`)).toEqual({
+      id: `3`,
+      name: `John Smith`,
+    })
+
+    // Insert a new person
+    emitter.emit(`sync`, [
+      {
+        key: `4`,
+        type: `insert`,
+        changes: {
+          id: `4`,
+          name: `Kyle Doe`,
+          age: 40,
+          email: `kyle.doe@example.com`,
+          isActive: true,
+        },
+      },
+    ])
+
+    await waitForChanges()
+
+    expect(result.state.size).toBe(2)
+    expect(result.state.get(`3`)).toEqual({
+      id: `3`,
+      name: `John Smith`,
+    })
+    expect(result.state.get(`4`)).toEqual({
+      id: `4`,
+      name: `Kyle Doe`,
+    })
+
+    // Update the person
+    emitter.emit(`sync`, [
+      {
+        key: `4`,
+        type: `update`,
+        changes: {
+          name: `Kyle Doe 2`,
+        },
+      },
+    ])
+
+    await waitForChanges()
+
+    expect(result.state.size).toBe(2)
+    expect(result.state.get(`4`)).toEqual({
+      id: `4`,
+      name: `Kyle Doe 2`,
+    })
+
+    // Delete the person
+    emitter.emit(`sync`, [
+      {
+        key: `4`,
+        type: `delete`,
+      },
+    ])
+
+    await waitForChanges()
+
+    expect(result.state.size).toBe(1)
+    expect(result.state.get(`4`)).toBeUndefined()
+  })
+})
+
+async function waitForChanges(ms = 100) {
+  await new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/packages/optimistic/tests/query/table-alias.test.ts
+++ b/packages/optimistic/tests/query/table-alias.test.ts
@@ -7,9 +7,9 @@ import {
   output,
   v,
 } from "@electric-sql/d2ts"
-import { compileQuery } from "../../src/query/index.js"
+import { compileQueryPipeline } from "../../src/query/pipeline-compiler.js"
 import type { Message } from "@electric-sql/d2ts"
-import type { Condition, Query } from "../../src/query/index.js"
+import type { Condition, Query } from "../../src/query/schema.js"
 
 describe(`Query - Table Aliasing`, () => {
   // Define a sample data type for our tests
@@ -87,7 +87,7 @@ describe(`Query - Table Aliasing`, () => {
 
     const graph = new D2({ initialFrontier: v([0, 0]) })
     const input = graph.newInput<Product>()
-    const pipeline = compileQuery(query, { [query.from]: input })
+    const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
     const messages: Array<Message<any>> = []
     pipeline.pipe(
@@ -132,7 +132,7 @@ describe(`Query - Table Aliasing`, () => {
 
     const graph = new D2({ initialFrontier: v([0, 0]) })
     const input = graph.newInput<Product>()
-    const pipeline = compileQuery(query, { [query.from]: input })
+    const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
     const messages: Array<Message<any>> = []
     pipeline.pipe(
@@ -176,7 +176,7 @@ describe(`Query - Table Aliasing`, () => {
 
     const graph = new D2({ initialFrontier: v([0, 0]) })
     const input = graph.newInput<Product>()
-    const pipeline = compileQuery(query, { [query.from]: input })
+    const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
     const messages: Array<Message<any>> = []
     pipeline.pipe(
@@ -230,7 +230,7 @@ describe(`Query - Table Aliasing`, () => {
 
     const graph = new D2({ initialFrontier: v([0, 0]) })
     const input = graph.newInput<Product>()
-    const pipeline = compileQuery(query, { [query.from]: input })
+    const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
     const messages: Array<Message<any>> = []
     pipeline.pipe(
@@ -288,7 +288,7 @@ describe(`Query - Table Aliasing`, () => {
 
     const graph = new D2({ initialFrontier: v([0, 0]) })
     const input = graph.newInput<Product>()
-    const pipeline = compileQuery(query, { [query.from]: input })
+    const pipeline = compileQueryPipeline(query, { [query.from]: input })
 
     const messages: Array<Message<any>> = []
     pipeline.pipe(

--- a/packages/optimistic/tests/query/wildcard-select.test.ts
+++ b/packages/optimistic/tests/query/wildcard-select.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test } from "vitest"
 import { D2, MessageType, MultiSet, output, v } from "@electric-sql/d2ts"
-import { compileQuery } from "../../src/query/compiler.js"
+import { compileQueryPipeline } from "../../src/query/pipeline-compiler.js"
 import type { Query } from "../../src/query/schema.js"
 
 // Define types for our test records
@@ -91,7 +91,9 @@ describe(`Query Wildcard Select`, () => {
   // Helper function to run a query with only users data
   const runUserQuery = (query: Query) => {
     // Compile the query
-    const pipeline = compileQuery<any>(query, { users: usersInput as any })
+    const pipeline = compileQueryPipeline<any>(query, {
+      users: usersInput as any,
+    })
 
     // Create an output to collect the results
     const outputOp = output<any>((message) => {
@@ -120,7 +122,7 @@ describe(`Query Wildcard Select`, () => {
   // Helper function to run a query with both users and orders data
   const runJoinQuery = (query: Query) => {
     // Compile the query
-    const pipeline = compileQuery<any>(query, {
+    const pipeline = compileQueryPipeline<any>(query, {
       users: usersInput as any,
       orders: ordersInput as any,
     })

--- a/packages/optimistic/tests/query/with.test.ts
+++ b/packages/optimistic/tests/query/with.test.ts
@@ -7,9 +7,9 @@ import {
   output,
   v,
 } from "@electric-sql/d2ts"
-import { compileQuery } from "../../src/query/compiler.js"
+import { compileQueryPipeline } from "../../src/query/pipeline-compiler.js"
 import type { Message } from "@electric-sql/d2ts"
-import type { Query } from "../../src/query/index.js"
+import type { Query } from "../../src/query/schema.js"
 
 // Sample user type for tests
 type User = {
@@ -68,7 +68,7 @@ describe(`Query`, () => {
 
       const graph = new D2({ initialFrontier: v([0, 0]) })
       const input = graph.newInput<User>()
-      const pipeline = compileQuery(query, { users: input })
+      const pipeline = compileQueryPipeline(query, { users: input })
 
       const messages: Array<Message<any>> = []
       pipeline.pipe(
@@ -133,7 +133,7 @@ describe(`Query`, () => {
 
       const graph = new D2({ initialFrontier: v([0, 0]) })
       const input = graph.newInput<User>()
-      const pipeline = compileQuery(query, { users: input })
+      const pipeline = compileQueryPipeline(query, { users: input })
 
       const messages: Array<Message<any>> = []
       pipeline.pipe(
@@ -186,7 +186,7 @@ describe(`Query`, () => {
 
       // Should throw an error because the CTE is missing the 'as' property
       expect(() => {
-        compileQuery(invalidQuery as any, { users: input })
+        compileQueryPipeline(invalidQuery as any, { users: input })
       }).toThrow(`WITH query must have an "as" property`)
     })
 
@@ -210,7 +210,7 @@ describe(`Query`, () => {
 
       // Should throw an error because the CTE has a keyBy property
       expect(() => {
-        compileQuery(invalidQuery as any, { users: input })
+        compileQueryPipeline(invalidQuery as any, { users: input })
       }).toThrow(`WITH query cannot have a "keyBy" property`)
     })
 
@@ -240,7 +240,7 @@ describe(`Query`, () => {
 
       // Should throw an error because of duplicate CTE names
       expect(() => {
-        compileQuery(invalidQuery as any, { users: input })
+        compileQueryPipeline(invalidQuery as any, { users: input })
       }).toThrow(`CTE with name "filtered_users" already exists`)
     })
 
@@ -264,7 +264,7 @@ describe(`Query`, () => {
 
       // Should throw an error because the referenced CTE doesn't exist
       expect(() => {
-        compileQuery(invalidQuery as any, { users: input })
+        compileQueryPipeline(invalidQuery as any, { users: input })
       }).toThrow(`Input for table "non_existent_cte" not found in inputs map`)
     })
   })


### PR DESCRIPTION
Working query compiler and execution for Collections:

```ts
// Start with a collection
const collection = new Collection<Person>({
  // config...
})

// Build a query
const query = queryBuilder()
  .from({ collection })
  .where(`@age`, `>`, 30)
  .keyBy(`@id`) // <- required at the moment
  .select(`@id`, `@name`)

// Compile it
const compiledQuery = compileQuery(query)

// Start the query
compiledQuery.start()

// Get the "ResultCollection"
const result = compiledQuery.results
```

Outstanding things to do - probably in a followup PR:
- Make it work with un-keyed queries
- More tests! (we only have a small basic test at the moment...
- Refine what a `ResultCollection` is
- React hooks